### PR TITLE
WIP: updates for current LiberTEM version

### DIFF
--- a/nionswift_plugin/LiberTEM_IO/OpenFileDialog.py
+++ b/nionswift_plugin/LiberTEM_IO/OpenFileDialog.py
@@ -57,7 +57,7 @@ class OpenFileDialogUI:
         params = {
             'hdf5':[{'text': 'Name', 'type': 'text_box', 'id': 'name'}, {'text': 'HDF5 Dataset Path', 'type': 'text_box', 'id': 'ds_path'}, {'text': 'Tileshape', 'type': 'text_box', 'id': 'tileshape', 'converter': 'tuple_to_string_converter'}],
             'raw':[{'text': 'Name', 'type': 'text_box', 'id': 'name'}, {'text': 'Scan Size', 'type': 'text_box', 'id': 'scan_size', 'converter': 'tuple_to_string_converter'}, {'text': 'Datatype', 'type': 'text_box', 'id': 'dtype'}, {'text': 'Detector Size', 'type': 'text_box', 'id': 'detector_size', 'converter': 'tuple_to_string_converter'}, {'text': 'Enable Direct I/O', 'type': 'check_box', 'id': 'enable_direct'}],
-            'mib':[{'text': 'Name', 'type': 'text_box', 'id': 'name'}, {'text': 'Tileshape', 'type': 'text_box', 'id': 'tileshape', 'converter': 'tuple_to_string_converter'}, {'text': 'Scan Size', 'type': 'text_box', 'id': 'scan_size', 'converter': 'tuple_to_string_converter'}],
+            'mib':[{'text': 'Name', 'type': 'text_box', 'id': 'name'}, {'text': 'Scan Size', 'type': 'text_box', 'id': 'nav_shape', 'converter': 'tuple_to_string_converter'}],
             'blo':[{'text': 'Name', 'type': 'text_box', 'id': 'name'}, {'text': 'Tileshape', 'type': 'text_box', 'id': 'tileshape', 'converter': 'tuple_to_string_converter'}],
             'k2is':[{'text': 'Name', 'type': 'text_box', 'id': 'name'}],
             'ser':[{'text': 'Name', 'type': 'text_box', 'id': 'name'}],

--- a/nionswift_plugin/LiberTEM_IO/__init__.py
+++ b/nionswift_plugin/LiberTEM_IO/__init__.py
@@ -70,7 +70,8 @@ class LiberTEMIODelegate:
         return self.read_data_and_metadata_from_stream(file_path)
 
     def read_data_and_metadata_from_stream(self, stream):
-        executor = Registry.get_component('libertem_executor')
+        context = Registry.get_component('libertem_context')
+        executor = context.executor
         if executor is None:
             logging.error('No libertem executor could be retrieved from the Registry.')
             return
@@ -92,7 +93,7 @@ class LiberTEMIODelegate:
         file_params.pop('name', None)
         file_parameters.update(file_params)
 
-        ds = dataset.load(file_type, executor, **file_parameters)
+        ds = context.load(file_type, **file_parameters)
         roi = np.zeros(ds.shape.nav, dtype=bool)
         roi_flat = roi.ravel()
         roi_flat[0] = True


### PR DESCRIPTION
I tried to reanimate this plugin for current LiberTEM (and nion) versions. The code runs so far as it doesn't crash at start-up, and it's possible to select files for opening. Sadly, after clicking the "Open" button in the system file dialog, the following error is logged, and clicking the "Load" button doesn't seem to have an effect, beyond closing the load dialog:

```
Traceback (most recent call last):


  File "/home/alex/miniconda/envs/nion/lib/python3.10/site-packages/nion/ui/PyQtProxy.py", line 271, in __periodic
    self.object.periodic()


  File "/home/alex/miniconda/envs/nion/lib/python3.10/site-packages/nion/ui/QtUserInterface.py", line 1931, in periodic
    self._handle_periodic()


  File "/home/alex/miniconda/envs/nion/lib/python3.10/site-packages/nion/ui/UserInterface.py", line 3506, in _handle_periodic
    self.on_periodic()


  File "/home/alex/miniconda/envs/nion/lib/python3.10/site-packages/nion/ui/Window.py", line 364, in periodic
    self.__event_loop.run_forever()


  File "/home/alex/miniconda/envs/nion/lib/python3.10/asyncio/base_events.py", line 590, in run_forever
    self._check_running()


  File "/home/alex/miniconda/envs/nion/lib/python3.10/asyncio/base_events.py", line 582, in _check_running
    raise RuntimeError('This event loop is already running')


RuntimeError: This event loop is already running
```

I'm not sure what is going wrong there - I thought maybe this is because of fork safety issues, but setting the multiprocessing start method to spawn didn't seem to fix things. Maybe I also did something wrong when installing nion swift, as I didn't find the right link to the development setup docs and did things from memory.

## TODO

- [ ] Fix the above-mentioned bug
- [ ] Further updates for I/O parameter handling (i.e. update for current formats and parameters supported by LiberTEM)
- [ ] Maybe updates regarding to the current nion swift version?